### PR TITLE
create unique name for typeB financials

### DIFF
--- a/fca_bulk_financials.js
+++ b/fca_bulk_financials.js
@@ -43,8 +43,8 @@ bulk(
         return null;
       }
 
-      //let minE = arr[0].EntryNo_, maxE = arr[0].EntryNo_;
-      let maxE = arr[0].EntryNo_;
+      const projectNo = arr[0].ProjectNr;
+      let minE = arr[0].EntryNo_, maxE = arr[0].EntryNo_;
       let minD = arr[0].DocumentNo_, maxD = arr[0].DocumentNo_;
       let maxP = transformDate(arr[0].PostingDate);
       //let minP = transformDate(arr[0].PostingDate), maxP = transformDate(arr[0].PostingDate);
@@ -64,7 +64,7 @@ bulk(
       }
 
       return {
-        EntryNo_: `${maxE}`,
+        uniqueName: `${maxE}-${minE}-${projectNo}`,
         DocumentNo_: `${minD} - ${maxD}`,
         PostingDate: `${maxP}`
       };
@@ -86,7 +86,7 @@ bulk(
           Credit_Amount__c: 0,
           Debit_Amount__c: 0,
           Document_Number__c: ranges.DocumentNo_,
-          Name: ranges.EntryNo_,
+          Name: ranges.uniqueName,
           Date_For_Currency_Conversion__c: ranges.PostingDate
           // Project_Series__c: '', // intentionally left blank
           // Staff_Code__c: '', // intentionally left blank


### PR DESCRIPTION
@aleksa-krolls , this has been tested on fakeAdaptor and works as intended. (Output below.) Note the `Name` for a typeB financial below. Please merge if this looks ok:
```json
        {
          "ampi__Budget__r.Budget_Unique_Identifier__c": "13006",
          "ampi__Reporting_Period__r.Reporting_Period_Unique_Identifier__c": "13006",
          "Project_Number__r.Project_Number_External_ID__c": "13006",
          "Account_Name__c": "Donations",
          "Account_Number__c": "3310 - 3888",
          "ampi__Amount_Actual__c": -45,
          "ampi__Description__c": "Donations",
          "Credit_Amount__c": 45,
          "Debit_Amount__c": 0,
          "Document_Number__c": "N001580 - Z001580",
          "Name": "6269731-6269731-13006",
          "Date_For_Currency_Conversion__c": "2013-12-29"
        }
```